### PR TITLE
Fixed a bug when Amazon image filenames contained U+005E (^)

### DIFF
--- a/packages/paapi-item-image-url-parser/src/PaapiItemImageUrl.ts
+++ b/packages/paapi-item-image-url-parser/src/PaapiItemImageUrl.ts
@@ -18,7 +18,9 @@ export default class {
 	constructor(inputUrl: URL) {
 		this.#url = inputUrl;
 
-		const matchGroups = /(?<dir>\/images\/[A-Z])\/(?<id>[a-zA-Z0-9\-_+%]+)(\._SL(?<size>[0-9]+)_)?(?<ext>\.[a-zA-Z0-9]+)$/.exec(inputUrl.pathname)?.groups;
+		const matchGroups = /(?<dir>\/images\/[A-Z])\/(?<id>[a-zA-Z0-9\-_+%]+)(\._SL(?<size>[0-9]+)_)?(?<ext>\.[a-zA-Z0-9]+)$/.exec(
+			decodeURIComponent(inputUrl.pathname),
+		)?.groups;
 		if (matchGroups === undefined) {
 			throw new Error('The format of the URL does not seem to be that of an Amazon product image.');
 		}


### PR DESCRIPTION
Node.js v24.5.0 で発生するようになったバグ。

- Node.js v24.5.0 では `ada` のアップデートが行われた👉 https://github.com/nodejs/node/pull/58966
- `ada@3.2.6` では U+005E (^) に関するバグが修正されている 👉 https://github.com/ada-url/ada/pull/974
- #30 で Node.js のバージョンを 22 → 24 にアップデートしたことで本プログラムにおいても発覚した