### PR TITLE
Fixed lint errors caused by ESLint configuration

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -21,7 +21,7 @@ export default [
 		},
 	},
 	{
-		files: ['packages/console-locale-timestamp/src/ConsoleLocaleTimestamp.ts'],
+		files: ['packages/console-locale-timestamp/src/Console.ts'],
 		rules: {
 			'class-methods-use-this': 'off',
 			'no-console': 'off',


### PR DESCRIPTION
#27 でファイル名を変更したのに対して ESLint 設定ファイルの追従を忘れていたため lint エラーが発生していた