### PR TITLE
[sqlite-utility] Remove the import of obsoluted functions from the documentation

### DIFF
--- a/packages/sqlite-utility/README.md
+++ b/packages/sqlite-utility/README.md
@@ -6,7 +6,7 @@
 ## Examples
 
 ```JavaScript
-import { jsToSQLiteComparison, jsToSQLiteAssignment, sqliteToJS, prepareSelect, prepareInsert, prepareUpdate, prepareDelete } from '@w0s/sqlite-utility';
+import { jsToSQLiteComparison, jsToSQLiteAssignment, sqliteToJS } from '@w0s/sqlite-utility';
 
 jsToSQLiteComparison('text'); // 'text'
 jsToSQLiteComparison(123); // 123


### PR DESCRIPTION
Omissions in handling #98